### PR TITLE
Supply working build instructions for Mac OS X

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-    Linear C++
+Linear C++
 
 A C++ tutorial that can (hopefully?) be followed without jumping from chapter to
 chapter at every step.
@@ -8,9 +8,13 @@ Download at: https://github.com/jesyspa/linear-cpp/archive/master.zip
 Via a bash shell, compiling all chapters:
 
     for a in Chapter*; do g++ -std=c++11 -o "$a/out" "$a"/*.cpp; done
+	
+On OSX:
 
-If you're on OS X, you should probably get clang with XCode instead; in that
-case, the above command should use clang++ instead of g++.
+	- You must install XCode and the Command Line Tools package. As of 9/04/2013, Mac OS X doesn't ship with a C++11 compiler.
+	- Then use clang to build:
+
+	for a in Chapter*; do clang++ --std=c++11 --stdlib=libc++ "$a"/*.cpp -o "$a"/out; done
 
 Also, when compiling your own files on either of those two platforms, I
 recommend you add -Wall and -Wextra to your flags.  Clang users may also want to


### PR DESCRIPTION
-stdlib=c++11 is required on Mac OS X. Otherwise Chapter 12 fails to build:

Chapter 12 - Function Templates/vector_algos.hpp:180:17: error: no member named 'all_of' in namespace 'std'

This is a limitation of the default std library for clang, stdc++
